### PR TITLE
 Use local storage for storing sketches

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -248,6 +248,20 @@ a {
     padding-top: 0;
 }
 
+.localversion {
+    position: fixed;
+    color: white;
+    top: 15px;
+    left: 240px;
+    height: 50px;
+    z-index: 1000;
+}
+
+.localversion .button {
+    margin-left: 10px;
+    margin-right: 0;
+}
+
 .editor__source-wrap,
 .editor__viewer-wrap {
     flex: 1;

--- a/js/editor.js
+++ b/js/editor.js
@@ -383,6 +383,7 @@ class Sketch extends Component {
         const ref = firebase.database().ref('sketch').push();
         ref.set(sketch, () => {
             this.setState({ saving: false, unsaved: false });
+            window.localStorage.removeItem(this.props.id || 'empty');
             route(`/sketch/${ref.key}`);
         }).then(() => {
             firebase.database().goOffline();


### PR DESCRIPTION
'beforeunload' is not reliable in preventing users from losing changes to their sketches. Having a locally stored version can come in handy in these cases.