### PR TITLE
Add a /view page

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -5,9 +5,15 @@
             "firebase.json",
             "**/.*"
         ],
-        "rewrites": [{
-            "source": "**",
-            "destination": "/index.html"
-        }]
+        "rewrites": [
+            {
+                "source": "/view/**",
+                "destination": "/view.html"
+            },
+            {
+                "source": "**",
+                "destination": "/index.html"
+            }
+        ]
     }
 }

--- a/view.html
+++ b/view.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Seed</title>
+</head>
+<body>
+    <script src="/third_party/bundle.min.js"></script>
+    <script src="/js/core.js"></script>
+    <script>
+    if (!document.location.search.startsWith('?id=')) {
+        throw new Error('No sketch ID');
+    }
+    const sketchId = document.location.search.substring(4);
+    console.log(sketchId);
+
+    async function loadSketch(id) {
+        const res = await fetch(`https://emrg-pcg.firebaseio.com/sketch/${id}.json`);
+        const json = await res.json();
+        const phraseBook = await parsePhraseBook(json.source, loadSketch);
+        return phraseBook;
+    }
+    (async() => {
+        const phraseBook = await loadSketch(sketchId);
+        const result = generateString(phraseBook, 'root', {}, 'ABC');
+        console.log(result);
+        document.write(result);
+    })();
+
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This page shows the sketch without any extra elements. It renders the content and writes it out directly into the page.

- [ ] Correct /view routing using Firebase
- [ ] Support random seed in URL bar
- [ ] Add support for sketches that use import (e.g. sketch `-L5wbLHtyOhej49zKNMh`)

This implements #32 .

To try locally,  use `serve -s`, then open http://localhost:5000/view.html?id=-L4uLB99JzFHMPcVoiTm